### PR TITLE
Fixing signal sign handling and functional testing - follow-up

### DIFF
--- a/src/cantypes.hpp
+++ b/src/cantypes.hpp
@@ -6,12 +6,15 @@
 #include <string>
 #include <vector>
 
-enum class CANsignalType { Int, Float, String };
-
 struct CANsignal {
+
+    // plain enums to retain backwards compatibility
+    enum ByteOrder { Motorola = 0, Intel = 1 };
+    enum SignType { Unsigned = false, Signed = true};
+
     // Constructor required for vs2015
     CANsignal(std::string _signal_name, std::uint8_t _startBit,
-        std::uint8_t _signalSize, std::uint8_t _byteOrder, bool _valueSigned,
+        std::uint8_t _signalSize, CANsignal::ByteOrder _byteOrder, CANsignal::SignType _valueSigned,
         float _factor, float _offset, float _min, float _max, std::string _unit,
         std::vector<std::string> _receiver, const std::string& _mux = "",
         std::uint8_t _muxNdx = 0)
@@ -34,8 +37,8 @@ struct CANsignal {
     std::string signal_name;
     std::uint8_t startBit;
     std::uint8_t signalSize;
-    std::uint8_t byteOrder;
-    bool valueSigned;
+    CANsignal::ByteOrder byteOrder;
+    CANsignal::SignType valueSigned;
     float factor;
     float offset;
     float min;
@@ -47,7 +50,14 @@ struct CANsignal {
 
     bool operator==(const CANsignal& rhs) const
     {
-        return signal_name == rhs.signal_name;
+        return (signal_name == rhs.signal_name) &&
+               (startBit == rhs.startBit) &&
+               (signalSize == rhs.signalSize) &&
+               (byteOrder == rhs.byteOrder) &&
+               (valueSigned == rhs.valueSigned) &&
+               (factor == rhs.factor) &&
+               (offset == rhs.offset);
+        // Theres is more to compare, yet this is the logical minimum.
     }
 };
 

--- a/src/dbc_grammar.peg
+++ b/src/dbc_grammar.peg
@@ -34,11 +34,12 @@ vals                    <- < 'VAL_' s* number s* TOKEN s* number s* phrase s* (n
 comment                 <- '//' (!NewLine .)* NewLine
 sig_val                 <- < 'SIG_VALTYPE_' s* number s* TOKEN s* ':' s* number ';' > NewLine
 
-signal                  <- < s* 'SG_' s* TOKEN s* mux? mux_ndx? s* ':' s* number '|' number '@' number sign s* '(' number ',' s* number ')' s* '[' number '|' number ']' s* phrase s* ECU_TOKEN (',' ECU_TOKEN)* > NewLine
+signal                  <- < s* 'SG_' s* TOKEN s* mux? mux_ndx? s* ':' s* number '|' number '@' number sig_sign s* '(' number ',' s* number ')' s* '[' number '|' number ']' s* phrase s* ECU_TOKEN (',' ECU_TOKEN)* > NewLine
 val_entry               <- < 'VAL_TABLE_' s* TOKEN s (number_phrase_pair)* ';' > NewLine
 number_phrase_pair      <- number s phrase s
 phrase                  <- < '"' (!'"' .)* '"' >
 sign                    <- < [-+] > _
+sig_sign                <- < [-+] > _
 TOKEN                   <- [a-zA-Z0-9'_']+
 ECU_TOKEN               <- [a-zA-Z0-9'_']+
 ENUM_VAL                <- (!';' .)+

--- a/tests/dbc_parser_data.hpp
+++ b/tests/dbc_parser_data.hpp
@@ -19,6 +19,12 @@ const std::string bo2 = R"(BO_ 257 GTW_epasControl: 3 NEO
   SG_ GTW_epasPowerMode : 1|4@1+ (1,0) [4|14] "" NEO
   SG_ GTW_epasTuneRequest : 5|3@1+ (1,0) [8|-1] "" NEO)";
 
+const std::string bo_signed_sigs = R"(BO_ 1091 FKD_Gyro_04: 6 NEO
+  SG_ FKD_GyroRoll : 32|9@1- (0.1,0) [-25.6|25.5] "" Vector__XXX
+  SG_ FKD_GyroPitch : 16|9@1- (0.1,0) [-25.6|25.5] "" Vector__XXX
+  SG_ FKD_GyroHead : 0|12@1+ (0.1,0) [0|409.5] "" Vector__XXX
+)";
+
 // This is windows newline
 const std::string bo_with_window_endline = R"(BO_ 666 GTW_stupidSt: 3 NEO SG_ GTW_epasTuneRequest : 5|3@1+ (1,0) [8|-1] "" NEO)";
 

--- a/tests/dbcparser_tests.cpp
+++ b/tests/dbcparser_tests.cpp
@@ -199,7 +199,7 @@ BU_ :
 
 )";
     std::vector<std::string> values{ test_data::bo1, test_data::bo2,
-        test_data::bo_with_window_endline };
+        test_data::bo_with_window_endline, test_data::bo_signed_sigs };
     for (const auto& value : values) {
         dbc += value;
         dbc += "\n";
@@ -212,40 +212,54 @@ BU_ :
 
     // bo1
     std::vector<CANsignal> expectedSignals;
-    expectedSignals.push_back(CANsignal{ "DAS_steeringControlType", 23, 2, 0,
-        "+", 1, 0, 0, 0, "", { { "EPAS" } } });
-    expectedSignals.push_back(CANsignal{ "DAS_steeringControlChecksum", 31, 8,
-        0, "+", 1, 0, 0, 0, "", { { "EPAS" } } });
+    expectedSignals.push_back(CANsignal{ "DAS_steeringControlType", 23, 2, CANsignal::Motorola,
+        CANsignal::Unsigned, 1, 0, 0, 0, "", { { "EPAS" } } });
+    expectedSignals.push_back(CANsignal{ "DAS_steeringControlChecksum", 31, 8, CANsignal::Motorola,
+        CANsignal::Unsigned, 1, 0, 0, 0, "", { { "EPAS" } } });
     expectedSignals.push_back(CANsignal{
-        "DAS_steeringControlType", 19, 4, 0, "+", 1, 0, 0, 0, "", { "EPAS" } });
+        "DAS_steeringControlType", 19, 4, CANsignal::Motorola, CANsignal::Unsigned, 1, 0, 0, 0, "", { "EPAS" } });
     expectedSignals.push_back(CANsignal{
-        "DAS_steeringControlType", 7, 2, 0, "+", 1, 0, 0, 0, "", { "EPAS" } });
+        "DAS_steeringControlType", 7, 2, CANsignal::Motorola, CANsignal::Unsigned, 1, 0, 0, 0, "", { "EPAS" } });
+
     CANmessage msg{ 1160, "DAS_steeringControl", 4, "NEO" };
-    auto expSig = CANsignal{ "DAS_steeringControlType", 23, 2, 0, "+", 1, 0, 0,
+    auto expSig = CANsignal{ "DAS_steeringControlType", 23, 2, CANsignal::Motorola, CANsignal::Unsigned, 1, 0, 0,
         0, "", { "EPAS" } };
 
     ASSERT_EQ(parser.getDb().messages.size(), values.size());
     ASSERT_EQ(parser.getDb().messages.at(msg).size(), 6u);
     EXPECT_EQ(parser.getDb().messages.at(msg).at(0), expSig);
 
-    expSig = CANsignal{ "DAS_steeringControlChecksum", 31, 8, 0, "+", 1, 0, 0,
+    expSig = CANsignal{ "DAS_steeringControlChecksum", 31, 8, CANsignal::Motorola, CANsignal::Unsigned, 1, 0, 0,
         0, "", { "EPAS" } };
     EXPECT_EQ(parser.getDb().messages.at(msg).at(1), expSig);
 
-    expSig = CANsignal{ "DAS_steeringControlCounter", 19, 4, 0, "+", 1, 0, 0, 0,
+    expSig = CANsignal{ "DAS_steeringControlCounter", 14, 7, CANsignal::Motorola, CANsignal::Unsigned, 15.0, 0, 0, 1425.0,
         "", { "EPAS" } };
     EXPECT_EQ(parser.getDb().messages.at(msg).at(2), expSig);
 
-    expSig = CANsignal{ "DAS_steeringHapticRequest", 7, 1, 0, "+", 1, 0, 0, 0,
+    expSig = CANsignal{ "DAS_steeringHapticRequest", 7, 1, CANsignal::Motorola, CANsignal::Unsigned, 1, 0, 0, 0,
         "", { "EPAS" } };
     EXPECT_EQ(parser.getDb().messages.at(msg).at(3), expSig);
 
     msg = CANmessage{ 257, "GTW_epasControl", 3, "NEO" };
     ASSERT_EQ(parser.getDb().messages.at(msg).size(), 7u);
 
-    expSig = CANsignal{ "GTW_epasEmergencyOn", 0, 1, 0, "+", 1, 0, 2, -1, "",
+    expSig = CANsignal{ "GTW_epasEmergencyOn", 0, 1, CANsignal::Intel, CANsignal::Unsigned, 1, 0, 2, -1, "",
         { "EPAS" } };
     EXPECT_EQ(parser.getDb().messages.at(msg).at(3), expSig);
+
+    // testing for correct signal signage handling
+
+    CANmessage gyro{ 1091, "FKD_Gyro_04", 6, "NEO" };
+
+    expSig = CANsignal{ "FKD_GyroRoll", 32, 9, CANsignal::Intel, CANsignal::Signed, 0.1, 0, -25.6, 25.5, "", { "NEO" } };
+    EXPECT_EQ(parser.getDb().messages.at(gyro).at(0), expSig);
+
+    expSig = CANsignal{ "FKD_GyroPitch", 16, 9,  CANsignal::Intel, CANsignal::Signed, 0.1, 0, -25.6, 25.5, "", { "NEO" } };
+    EXPECT_EQ(parser.getDb().messages.at(gyro).at(1), expSig);
+
+    expSig = CANsignal{ "FKD_GyroHead", 0, 12, CANsignal::Intel, CANsignal::Unsigned, 0.1, 0, 0, 409.5, "", { "NEO" } };
+    EXPECT_EQ(parser.getDb().messages.at(gyro).at(2), expSig);
 }
 
 TEST_P(ValuesTest, vals)


### PR DESCRIPTION
_Disclaimer: Follow-up on PR #19 using a stable branch._

> Hi,
> 
> I came across somewhat serious issues regarding the handling of a signal's sign bit and the functional tests.
> 
>     The grammar specified a "sign" but did not distinguish the mandatory "+"/"-" sign of the entire signal from any signs that may be specified along with the factor, offset or range numbers. If there was a "-" in any of these, the "sign" was added to the stack but never used as it was part of a legitimate number. However, when taking the "sign" off the stack, the last added one from any of the numbers from the end of the signal is falsely taken as sign of the entire signal. If I'm not mistaken, orphaned signs might have been carried over to the next signal. Therefore, I've introduced a "sig_sign" in the grammar
> 
>     I've added my message that has shown the issue to your functional test as a reference. Doing this, I noticed that all your tests succeeded for as long as the name of a signal matched => I've adapted the comparison operator of CANsignal respectively and fixed some of otherwise failing tests.
> 
>     Strings for the signal sign e.g. "+" and "-" would have been cast to bool and would thus always evaluate to TRUE. To fix this issue and improve overall type safety, I've taken the liberty to introduce backwards-compatible enum symbols for both the signal sign as well as its byte order.
> 
> This time, I hope all will build well ;)

Regards,
Jens