### PR TITLE
std::stof fix

### DIFF
--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -3,6 +3,7 @@
 
 #include "cantypes.hpp"
 #include <string>
+#include <clocale>
 
 namespace CANdb {
 
@@ -10,8 +11,19 @@ template <typename Derived> struct Parser {
 
     bool parse(const std::string& data) noexcept
     {
+        // Store current LOCALE
+        std::string prevLocale = std::setlocale(LC_ALL, nullptr);
+        // To assure that std::stoX functions will produced the same results
+        // on systems with different LOCALE settings
+        std::setlocale(LC_ALL, "C");
+
         Derived* d = static_cast<Derived*>(this);
-        return d->parse(data);
+        auto ret = d->parse(data);
+
+        // Restore previous LOCALE for the application
+        std::setlocale(LC_ALL, prevLocale.c_str());
+
+        return ret;
     }
 
     CANdb_t getDb() const noexcept { return can_db; }


### PR DESCRIPTION
Fix for #21. On systems with "non-standard" LOCALE settings std::stoX functions may produce wrong results

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@gmail.com>