### PR TITLE
Fix several issues with the dbc parser

### DIFF
--- a/src/dbc_grammar.peg
+++ b/src/dbc_grammar.peg
@@ -38,7 +38,9 @@ sig_val                 <- < 'SIG_VALTYPE_' s* number s* TOKEN s* ':' s* number 
 signal                  <- < s* 'SG_' s* TOKEN s* mux? mux_ndx? s* ':' s* number '|' number '@' number sig_sign s* '(' number ',' s* number ')' s* '[' number '|' number ']' s* phrase s* ECU_TOKEN (',' ECU_TOKEN)* > NewLine
 val_entry               <- < 'VAL_TABLE_' s* TOKEN s (number_phrase_pair)* ';' > NewLine
 number_phrase_pair      <- number s phrase s
-phrase                  <- < '"' (!'"' .)* '"' >
+phrase                  <- < '"' (escaped_quote / string_char)* '"' >
+string_char             <- (!["] .)
+escaped_quote           <- '\\"'
 sign                    <- < [-+] > _
 sig_sign                <- < [-+] > _
 TOKEN                   <- [a-zA-Z0-9'_']+

--- a/src/dbc_grammar.peg
+++ b/src/dbc_grammar.peg
@@ -1,5 +1,5 @@
 # DBC Grammar
-grammar                 <- spacing _ version _ comment* ns_comment bs? _ (bu / bu_sl)? _ val_table? _ message* _ bo_tx_bu* _ cm* cm_bu* _ (cm_bo _ / cm_sg _)* _ (ba_def_str / ba_def_num / ba_def_enum / ba_def_rel)* _ (ba_def_def / ba_def_def_rel)* _ ba* _ ba_bu* _ ba_bo* _ ba_sg* _ ba_rel* vals* sig_val* _ EndOfFile
+grammar                 <- spacing _ version _ comment* ns_comment bs? _ (bu / bu_sl)? _ val_table? _ message* _ bo_tx_bu* _ cm* cm_bu* _ (cm_bo _ / cm_sg _)* _ ev* _ (ba_def_str / ba_def_num / ba_def_enum / ba_def_rel)* _ (ba_def_def / ba_def_def_rel)* _ ba* _ ba_bu* _ ba_bo* _ ba_sg* _ ba_rel* vals* sig_val* _ EndOfFile
 
 spacing                 <- (s / comment)*
 ns_comment              <- (ns? / comment)? NewLine*
@@ -15,6 +15,7 @@ cm                      <- < 'CM_' s* phrase > ';' NewLine
 cm_bu                   <- < 'CM_' s* 'BU_' s* TOKEN s* phrase > ';' NewLine
 cm_bo                   <- < 'CM_' s* 'BO_' s* integer s* phrase > ';' NewLine
 cm_sg                   <- < 'CM_' s* 'SG_' s* integer s* TOKEN s* phrase > ';' NewLine*
+ev                      <- < 'EV_' s* TOKEN ':' s* number s* '[' number '|' number ']' s* phrase s* number s* number s* TOKEN *s TOKEN > ';' NewLine*
 ba_def_str              <- (< 'BA_DEF_' s* (('BO_' / 'SG_' / 'BU_') s*)? phrase s* 'STRING' s* ';' > (NewLine / s* comment) ) / comment
 ba_def_num              <- (< 'BA_DEF_' s* (('BO_' / 'SG_' / 'BU_') s*)? phrase s* ('INT' / 'HEX' / 'FLOAT') s* number s* number ';' > (NewLine / s* comment) ) / comment
 ba_def_enum             <- (< 'BA_DEF_' s* (('BO_' / 'SG_' / 'BU_') s*)? phrase s* 'ENUM' s* ENUM_VAL';' > (NewLine / s* comment) ) / comment

--- a/src/dbc_grammar.peg
+++ b/src/dbc_grammar.peg
@@ -23,7 +23,7 @@ ba_def_def              <- < 'BA_DEF_DEF_' s* phrase s* (phrase / number ) ';' >
 ba                      <- < 'BA_' s* phrase s* (phrase / number ) ';' > NewLine
 ba_bu                   <- < 'BA_' s* phrase s* 'BU_' s* TOKEN s* (phrase / number) ';' > NewLine
 ba_bo                   <- < 'BA_' s* phrase s* 'BO_' s* number s* (phrase / number) s* ';' > NewLine
-ba_sg                   <- < 'BA_' s* phrase s* 'SG_' s* number s* TOKEN s* number s* ';' > NewLine
+ba_sg                   <- < 'BA_' s* phrase s* 'SG_' s* number s* TOKEN s* (phrase / number) s* ';' > NewLine
 # ignore ba_def_rel for now
 ba_def_rel              <- 'BA_DEF_REL_' (!NewLine .)* NewLine
 # ignore ba_def_def_rel for now

--- a/src/dbc_grammar.peg
+++ b/src/dbc_grammar.peg
@@ -16,7 +16,7 @@ cm_bu                   <- < 'CM_' s* 'BU_' s* TOKEN s* phrase > ';' NewLine
 cm_bo                   <- < 'CM_' s* 'BO_' s* integer s* phrase > ';' NewLine
 cm_sg                   <- < 'CM_' s* 'SG_' s* integer s* TOKEN s* phrase > ';' NewLine*
 ba_def_str              <- (< 'BA_DEF_' s* (('BO_' / 'SG_' / 'BU_') s*)? phrase s* 'STRING' s* ';' > (NewLine / s* comment) ) / comment
-ba_def_num              <- (< 'BA_DEF_' s* (('BO_' / 'SG_' / 'BU_') s*)? phrase s* ('INT' / 'HEX') s* number s* number ';' > (NewLine / s* comment) ) / comment
+ba_def_num              <- (< 'BA_DEF_' s* (('BO_' / 'SG_' / 'BU_') s*)? phrase s* ('INT' / 'HEX' / 'FLOAT') s* number s* number ';' > (NewLine / s* comment) ) / comment
 ba_def_enum             <- (< 'BA_DEF_' s* (('BO_' / 'SG_' / 'BU_') s*)? phrase s* 'ENUM' s* ENUM_VAL';' > (NewLine / s* comment) ) / comment
 ba_def_def              <- < 'BA_DEF_DEF_' s* phrase s* (phrase / number ) ';' > NewLine
 ba                      <- < 'BA_' s* phrase s* (phrase / number ) ';' > NewLine

--- a/src/dbcparser.cpp
+++ b/src/dbcparser.cpp
@@ -146,6 +146,12 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         cdb_warn("TAG BS Not implemented");
     };
 
+    pegParser["ev"] = [](const peg::SemanticValues& sv) {
+        // TODO: Implement me
+        cdb_warn("TAG EV Not implemented");
+        cdb_debug("Found environment variable [ev] {}", sv.token());
+    };
+
     pegParser["sign"] = [&signs](const peg::SemanticValues& sv) {
         cdb_debug("Found sign {}", sv.token());
         signs.push_back(sv.token());

--- a/tests/dbc/prop/comfort.dbc
+++ b/tests/dbc/prop/comfort.dbc
@@ -1,0 +1,131 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: SUT_Driver SUT
+
+
+BO_ 1536 DiagResponse: 8 Vector__XXX
+
+BO_ 1792 DiagRequest: 8 Vector__XXX
+
+BO_ 1 LockingRemoteControlRequest: 1 SUT_Driver
+ SG_ LockRequest : 0|2@1+ (1,0) [0|0] ""  SUT
+
+BO_ 0 CentralLockingSystemState: 1 SUT
+ SG_ AntiTheftSystemActive : 1|1@1+ (1,2) [2|10] "" Vector__XXX
+ SG_ LockState : 0|1@1+ (2,3) [3|5] "" Vector__XXX
+
+BO_ 50 VehicleMotion: 3 SUT_Driver
+ SG_ EngineRunning : 17|1@1+ (3,0) [1|3] "" Vector__XXX
+ SG_ CrashDetected : 16|1@1+ (1,0) [0|0] ""  SUT
+ SG_ Velocity : 0|16@1- (3,0) [1|4] ""  SUT
+
+BO_ 100 WindowState: 2 SUT
+ SG_ WindowPosition : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ WindowMotion : 14|2@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 101 WindowControl: 1 SUT_Driver
+ SG_ KeyDown : 1|1@1+ (1,0) [0|0] ""  SUT
+ SG_ KeyUp : 0|1@1+ (1,0) [0|1] ""  SUT
+
+
+
+EV_ DoorClosed: 0 [0|1] "" 0 1 DUMMY_NODE_VECTOR0 Vector__XXX;
+
+EV_ rbbpPowermode: 0 [0|5] "" 0 2 DUMMY_NODE_VECTOR0 Vector__XXX;
+
+BA_DEF_  "NmMessageCount" INT 0 0;
+BA_DEF_ BO_  "DiagResponse" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagRequest" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgFastOnStart" INT 0 0;
+BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 0;
+BA_DEF_ SG_  "NWM-WakeupAllowed" ENUM  "No","Yes";
+BA_DEF_ BO_  "NmMessage" ENUM  "no","yes";
+BA_DEF_ BO_  "GenMsgILSupport" ENUM  "No","Yes";
+BA_DEF_ BU_  "NmNode" ENUM  "no","yes";
+BA_DEF_ BU_  "NmStationAddress" INT 0 63;
+BA_DEF_  "NmBaseAddress" HEX 1024 1087;
+BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 50000;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 50000;
+BA_DEF_ BO_  "GenMsgDelayTime" INT 0 1000;
+BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 999999;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "Cyclic","NotUsed","NotUsed","NotUsed","NotUsed","Cyclic","NotUsed","IfActive","NoMsgSendType","NotUsed","vector_leerstring";
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 100000;
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed";
+BA_DEF_ SG_  "GenSigStartValue" FLOAT 0 100000000000;
+BA_DEF_DEF_  "NmMessageCount" 64;
+BA_DEF_DEF_  "DiagResponse" "No";
+BA_DEF_DEF_  "DiagRequest" "No";
+BA_DEF_DEF_  "GenMsgFastOnStart" 0;
+BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_  "NWM-WakeupAllowed" "";
+BA_DEF_DEF_  "NmMessage" "no";
+BA_DEF_DEF_  "GenMsgILSupport" "Yes";
+BA_DEF_DEF_  "NmNode" "no";
+BA_DEF_DEF_  "NmStationAddress" 0;
+BA_DEF_DEF_  "NmBaseAddress" 1024;
+BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "GenMsgCycleTime" 100;
+BA_DEF_DEF_  "GenMsgDelayTime" 0;
+BA_DEF_DEF_  "GenMsgNrOfRepetition" 0;
+BA_DEF_DEF_  "GenMsgSendType" "NoMsgSendType";
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "GenSigSendType" "Cyclic";
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_ "DiagResponse" BO_ 1536 1;
+BA_ "DiagRequest" BO_ 1792 1;
+BA_ "GenMsgDelayTime" BO_ 101 18;
+BA_ "GenMsgNrOfRepetition" BO_ 101 2;
+BA_ "GenMsgCycleTimeFast" BO_ 101 20;
+BA_ "GenMsgCycleTime" BO_ 101 500;
+BA_ "GenMsgSendType" BO_ 101 0;
+BA_ "GenSigSendType" SG_ 1 LockRequest 1;
+BA_ "GenSigStartValue" SG_ 0 AntiTheftSystemActive 6;
+BA_ "GenSigStartValue" SG_ 0 LockState 0.5;
+BA_ "GenSigStartValue" SG_ 50 EngineRunning 0.666666666666667;
+BA_ "GenSigSendType" SG_ 50 CrashDetected 1;
+BA_ "GenSigStartValue" SG_ 50 Velocity 1;
+BA_ "GenSigStartValue" SG_ 100 WindowPosition 3;
+BA_ "GenSigSendType" SG_ 100 WindowMotion 1;
+BA_ "GenSigSendType" SG_ 101 KeyDown 6;
+BA_ "GenSigSendType" SG_ 101 KeyUp 6;
+BA_ "GenSigStartValue" SG_ 101 KeyUp 1;
+VAL_ 1 LockRequest 3 "Comfort_lock" 2 "Request_unlock" 1 "Request_lock" 0 "idle" ;
+VAL_ 0 AntiTheftSystemActive 2 "currently_opening" 1 "currently_closing" 0 "not_moving" ;
+VAL_ 0 LockState 2 "currently_opening" 1 "currently_closing" 0 "not_moving" ;
+VAL_ 100 WindowMotion 2 "currently_opening" 1 "currently_closing" 0 "not_moving" ;
+

--- a/tests/prop_tests.cpp
+++ b/tests/prop_tests.cpp
@@ -15,3 +15,9 @@ TEST_F(PropDBCTest, extended_ids)
     const auto file = test_helper::loadDBCFile("prop/extended-ids.dbc");
     ASSERT_TRUE(parser.parse(file));
 }
+
+TEST_F(PropDBCTest, vector_file)
+{
+    const auto file = test_helper::loadDBCFile("prop/comfort.dbc");
+    ASSERT_TRUE(parser.parse(file));
+}


### PR DESCRIPTION
I could not load a dbc file produced by a recent version of CANdb++ similar to the one I added to this PR due to parser errors.

This PR contains the necessary fixes to `dbc_grammar.peg` alongside with a primitive test case.