### PR TITLE
Fixing handling of muxed messages

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ set(
   SRC
   dbcparser.cpp
   parsererror.cpp
+  cantypes.hpp
+  log.hpp
 )
 
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/dbc_grammar.peg DBC_GRAMMAR)

--- a/src/cantypes.hpp
+++ b/src/cantypes.hpp
@@ -8,16 +8,15 @@
 
 struct CANsignal {
 
-    // plain enums to retain backwards compatibility
     enum ByteOrder { Motorola = 0, Intel = 1 };
     enum SignType { Unsigned = false, Signed = true};
+    enum MuxIndex { /*mux slot 0 .. 253 */ MuxMaster = 0xFE, NonMuxed = 0xFF };
 
     // Constructor required for vs2015
     CANsignal(std::string _signal_name, std::uint8_t _startBit,
         std::uint8_t _signalSize, CANsignal::ByteOrder _byteOrder, CANsignal::SignType _valueSigned,
         float _factor, float _offset, float _min, float _max, std::string _unit,
-        std::vector<std::string> _receiver, const std::string& _mux = "",
-        std::uint8_t _muxNdx = 0)
+        std::vector<std::string> _receiver, std::uint8_t _muxNdx = NonMuxed)
         : signal_name(_signal_name)
         , startBit(_startBit)
         , signalSize(_signalSize)
@@ -29,7 +28,6 @@ struct CANsignal {
         , max(_max)
         , unit(_unit)
         , receiver(_receiver)
-        , mux(_mux)
         , muxNdx(_muxNdx)
     {
     }
@@ -45,8 +43,7 @@ struct CANsignal {
     float max;
     std::string unit;
     std::vector<std::string> receiver;
-    std::string mux = "";
-    std::uint8_t muxNdx{ 0 };
+    std::uint8_t muxNdx;
 
     bool operator==(const CANsignal& rhs) const
     {
@@ -56,19 +53,27 @@ struct CANsignal {
                (byteOrder == rhs.byteOrder) &&
                (valueSigned == rhs.valueSigned) &&
                (factor == rhs.factor) &&
-               (offset == rhs.offset);
-        // Theres is more to compare, yet this is the logical minimum.
+               (offset == rhs.offset) &&
+               (min == rhs.min) &&
+               (max == rhs.max) &&
+               (muxNdx == rhs.muxNdx);
+        // Theres is more to compare, yet this is the logical minimum without too much
+        // compromise on performance as the following arguably do not taint the signals
+        // structure
+        // (unit == rhs.unit)
+        // (receiver == rhs.receiver)
     }
 };
 
 struct CANmessage {
     // Constructor required for vs2015
     CANmessage(std::uint32_t _id, const std::string& _name = "",
-        std::uint32_t _dlc = 0, const std::string& _ecu = "")
+        std::uint32_t _dlc = 0, const std::string& _ecu = "", bool _muxed = false)
         : id(_id)
         , name(_name)
         , dlc(_dlc)
         , ecu(_ecu)
+        , muxed(_muxed)
     {
     }
 
@@ -76,6 +81,7 @@ struct CANmessage {
     std::string name;
     std::uint32_t dlc;
     std::string ecu;
+    bool muxed;
     std::uint32_t updateCycle{ 0 };
     std::string initValue{ "" };
 };

--- a/src/dbc_grammar.peg
+++ b/src/dbc_grammar.peg
@@ -35,7 +35,7 @@ vals                    <- < 'VAL_' s* number s* TOKEN s* number s* phrase s* (n
 comment                 <- '//' (!NewLine .)* NewLine
 sig_val                 <- < 'SIG_VALTYPE_' s* number s* TOKEN s* ':' s* number ';' > NewLine
 
-signal                  <- < s* 'SG_' s* TOKEN s* mux? mux_ndx? s* ':' s* number '|' number '@' number sig_sign s* '(' number ',' s* number ')' s* '[' number '|' number ']' s* phrase s* ECU_TOKEN (',' ECU_TOKEN)* > NewLine
+signal                  <- < s* 'SG_' s* TOKEN s* mux_master? mux_ndx? s* ':' s* number '|' number '@' number sig_sign s* '(' number ',' s* number ')' s* '[' number '|' number ']' s* phrase s* ECU_TOKEN (',' ECU_TOKEN)* > NewLine
 val_entry               <- < 'VAL_TABLE_' s* TOKEN s (number_phrase_pair)* ';' > NewLine
 number_phrase_pair      <- number s phrase s
 phrase                  <- < '"' (escaped_quote / string_char)* '"' >
@@ -48,9 +48,9 @@ ECU_TOKEN               <- [a-zA-Z0-9'_']+
 ENUM_VAL                <- (!';' .)+
 number                  <- double / integer
 integer                 <- < sign? [0-9]+ > _
-double                   <- < sign? ([0-9]+'.')?[0-9]+('E' sign [0-9]+)? > _
+double                  <- < sign? ([0-9]+'.')?[0-9]+('E' sign [0-9]+)? > _
 symbol_name             <- < s* TOKEN > NewLine
-mux                     <- 'M'
+mux_master              <- 'M'
 mux_ndx                 <- 'm'< [0-9]+ >
 
 EndOfFile               <- !.

--- a/src/dbcparser.cpp
+++ b/src/dbcparser.cpp
@@ -103,9 +103,6 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
     std::deque<std::string> idents, signs, sig_sign, ecu_tokens;
     std::deque<double> numbers;
 
-    bool mux = false;
-    int muxNdx = -1;
-
     using PhrasePair = std::pair<std::uint32_t, std::string>;
     std::vector<PhrasePair> phrasesPairs;
     CANdb_t can_db;
@@ -198,12 +195,13 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         phrasesPairs.clear();
     };
 
-    pegParser["mux"] = [&mux](const peg::SemanticValues&) { mux = true; };
-    pegParser["mux_ndx"] = [&muxNdx](const peg::SemanticValues& sv) { muxNdx = std::stoi(sv.token()); };
+    uint8_t muxNdx = CANsignal::NonMuxed;
+    bool muxedMsg = false;
 
     std::string muxName;
     std::vector<CANsignal> signals;
-    pegParser["message"] = [&can_db, &numbers, &signals, &idents, &mux, &muxNdx, &muxName](const peg::SemanticValues&) {
+    pegParser["message"] = [&can_db, &numbers, &signals, &idents,
+                            &muxNdx, &muxedMsg](const peg::SemanticValues&) {
         cdb_debug("Found a message {} signals = {}", idents.size(), signals.size());
         if (numbers.size() < 2 || idents.size() < 2) {
             return;
@@ -213,19 +211,25 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         auto ecu = take_back(idents);
         auto name = take_back(idents);
 
-        const CANmessage msg{ static_cast<std::uint32_t>(id), name, static_cast<std::uint32_t>(dlc), ecu };
+        const CANmessage msg{ static_cast<std::uint32_t>(id), name,
+                    static_cast<std::uint32_t>(dlc), ecu, muxedMsg };
         cdb_debug("Found a message with id = {}", msg.id);
         can_db.messages[msg] = signals;
         signals.clear();
         numbers.clear();
         idents.clear();
-        mux = false;
-        muxNdx = -1;
-        muxName = "";
+        muxedMsg = false;
     };
 
-    pegParser["signal"] = [&idents, &numbers, &phrases, &signals, &signs, &sig_sign, &ecu_tokens, &mux, &muxNdx,
-                              &muxName](const peg::SemanticValues& sv) {
+
+    pegParser["mux_master"] = [&muxNdx](const peg::SemanticValues&) { muxNdx = CANsignal::MuxMaster; };
+    pegParser["mux_ndx"] = [&muxNdx](const peg::SemanticValues& sv) {
+        muxNdx = std::stoi(sv.token());
+    };
+
+
+    pegParser["signal"] = [&idents, &numbers, &phrases, &signals, &signs, &sig_sign,
+                           &ecu_tokens, &muxNdx, &muxedMsg](const peg::SemanticValues& sv) {
         cdb_debug("Found signal {}", sv.token());
 
         const std::vector<std::string> receiver{ ecu_tokens.begin(), ecu_tokens.end() };
@@ -237,15 +241,6 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         auto factor = take_back(numbers);
         CANsignal::SignType valueSigned = (take_back(sig_sign) == "-") ? CANsignal::Signed : CANsignal::Unsigned;
 
-        std::string sigMuxName;
-        std::uint8_t sigMuxNdx = 0xff;
-
-        if (muxNdx != -1) {
-            sigMuxName = muxName;
-            sigMuxNdx = static_cast<std::uint8_t>(muxNdx);
-            muxNdx = -1;
-            cdb_debug("Signal: muxName {}, muxNdx {}", muxName, sigMuxNdx);
-        }
 
         CANsignal::ByteOrder byteOrder = (take_back(numbers) == 0) ? CANsignal::Motorola : CANsignal::Intel;
 
@@ -254,16 +249,22 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
 
         auto signal_name = take_back(idents);
 
-        if (mux) {
-            sigMuxName = muxName;
-            sigMuxNdx = static_cast<std::uint8_t>(muxNdx);
-            muxNdx = -1;
+        auto signal = CANsignal{ signal_name, static_cast<std::uint8_t>(startBit),
+            static_cast<std::uint8_t>(signalSize), byteOrder, valueSigned,
+            static_cast<float>(factor), static_cast<float>(offset),
+            static_cast<float>(min), static_cast<float>(max), unit,
+            receiver, muxNdx };
+
+        signals.push_back(std::move(signal));
+
+        if (muxNdx == CANsignal::MuxMaster) {
+            muxedMsg = true;
+            cdb_debug("Signal: muxMaster {}", signal_name);
+        } else if (muxNdx != CANsignal::NonMuxed) {
+            cdb_debug("Signal: MuxNdx{}, muxNdx {}", muxNdx);
         }
 
-        signals.push_back(
-            CANsignal{ signal_name, static_cast<std::uint8_t>(startBit), static_cast<std::uint8_t>(signalSize),
-                byteOrder, valueSigned, static_cast<float>(factor), static_cast<float>(offset), static_cast<float>(min),
-                static_cast<float>(max), unit, receiver, sigMuxName, sigMuxNdx });
+        muxNdx = CANsignal::NonMuxed;
     };
     return pegParser.parse(noTabsData.c_str())
         ? CANdb::CanDbOrError(can_db)

--- a/src/dbcparser.cpp
+++ b/src/dbcparser.cpp
@@ -200,8 +200,7 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
 
     std::string muxName;
     std::vector<CANsignal> signals;
-    pegParser["message"] = [&can_db, &numbers, &signals, &idents,
-                            &muxNdx, &muxedMsg](const peg::SemanticValues&) {
+    pegParser["message"] = [&can_db, &numbers, &signals, &idents, &muxNdx, &muxedMsg](const peg::SemanticValues&) {
         cdb_debug("Found a message {} signals = {}", idents.size(), signals.size());
         if (numbers.size() < 2 || idents.size() < 2) {
             return;
@@ -211,8 +210,7 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         auto ecu = take_back(idents);
         auto name = take_back(idents);
 
-        const CANmessage msg{ static_cast<std::uint32_t>(id), name,
-                    static_cast<std::uint32_t>(dlc), ecu, muxedMsg };
+        const CANmessage msg{ static_cast<std::uint32_t>(id), name, static_cast<std::uint32_t>(dlc), ecu, muxedMsg };
         cdb_debug("Found a message with id = {}", msg.id);
         can_db.messages[msg] = signals;
         signals.clear();
@@ -221,15 +219,11 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         muxedMsg = false;
     };
 
-
     pegParser["mux_master"] = [&muxNdx](const peg::SemanticValues&) { muxNdx = CANsignal::MuxMaster; };
-    pegParser["mux_ndx"] = [&muxNdx](const peg::SemanticValues& sv) {
-        muxNdx = std::stoi(sv.token());
-    };
+    pegParser["mux_ndx"] = [&muxNdx](const peg::SemanticValues& sv) { muxNdx = std::stoi(sv.token()); };
 
-
-    pegParser["signal"] = [&idents, &numbers, &phrases, &signals, &signs, &sig_sign,
-                           &ecu_tokens, &muxNdx, &muxedMsg](const peg::SemanticValues& sv) {
+    pegParser["signal"] = [&idents, &numbers, &phrases, &signals, &signs, &sig_sign, &ecu_tokens, &muxNdx, &muxedMsg](
+                              const peg::SemanticValues& sv) {
         cdb_debug("Found signal {}", sv.token());
 
         const std::vector<std::string> receiver{ ecu_tokens.begin(), ecu_tokens.end() };
@@ -241,7 +235,6 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         auto factor = take_back(numbers);
         CANsignal::SignType valueSigned = (take_back(sig_sign) == "-") ? CANsignal::Signed : CANsignal::Unsigned;
 
-
         CANsignal::ByteOrder byteOrder = (take_back(numbers) == 0) ? CANsignal::Motorola : CANsignal::Intel;
 
         auto signalSize = take_back(numbers);
@@ -250,10 +243,8 @@ CANdb::CanDbOrError parse(peg::parser& pegParser, const std::string& data)
         auto signal_name = take_back(idents);
 
         auto signal = CANsignal{ signal_name, static_cast<std::uint8_t>(startBit),
-            static_cast<std::uint8_t>(signalSize), byteOrder, valueSigned,
-            static_cast<float>(factor), static_cast<float>(offset),
-            static_cast<float>(min), static_cast<float>(max), unit,
-            receiver, muxNdx };
+            static_cast<std::uint8_t>(signalSize), byteOrder, valueSigned, static_cast<float>(factor),
+            static_cast<float>(offset), static_cast<float>(min), static_cast<float>(max), unit, receiver, muxNdx };
 
         signals.push_back(std::move(signal));
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(GoogleTest)
 function(candb_add_test test_name)
-  add_executable(${test_name} ${test_name}.cpp)
+  add_executable(${test_name} ${test_name}.cpp dbc_parser_data.hpp dbc_parser_data_win.hpp)
   gtest_discover_tests(${test_name})
   target_link_libraries(${test_name} CANdb gtest gtest_main test_helper)
   add_test(NAME ${test_name} COMMAND ${test_name})

--- a/tests/dbc_parser_data.hpp
+++ b/tests/dbc_parser_data.hpp
@@ -25,7 +25,22 @@ const std::string bo_signed_sigs = R"(BO_ 1091 FKD_Gyro_04: 6 NEO
   SG_ FKD_GyroHead : 0|12@1+ (0.1,0) [0|409.5] "" Vector__XXX
 )";
 
-// This is windows newline
-const std::string bo_with_window_endline = R"(BO_ 666 GTW_stupidSt: 3 NEO SG_ GTW_epasTuneRequest : 5|3@1+ (1,0) [8|-1] "" NEO)";
+const std::string bo_muxed_signals = R"(BO_ 2589283496 MN_MuxMsg_01: 8 MYNODE
+  SG_ MN_MUX M  : 0|2@1+ (1.0,0.0) [0.0|3] ""  Vector__XXX
+  SG_ MN_NonMuxed : 2|1@1+ (1.0,0.0) [0.0|1] ""  Vector__XXX
+  SG_ MN_MuxSig0_1 m0  : 3|4@1+ (1.0,0.0) [0.0|15] ""  Vector__XXX
+  SG_ MN_MuxSig1_1 m1  : 4|12@1+ (0.1,0) [0.0|409.5] ""  Vector__XXX
+  SG_ MN_MuxSig0_2 m0  : 7|1@1+ (1.0,0.0) [0.0|1] ""  Vector__XXX
+  SG_ MN_MuxSig0_3 m0  : 8|27@1+ (0.000001,0) [0.000000|90.000000] ""  Vector__XXX
+  SG_ MN_MuxSig1_2 m1  : 16|14@1+ (1,0) [0|16383] ""  Vector__XXX
+  SG_ MN_MuxSig1_3 m1  : 30|2@1+ (1.0,0.0) [0.0|3] ""  Vector__XXX
+  SG_ MN_MuxSig1_4 m1  : 32|32@1+ (1,0) [0|4294967295] ""  Vector__XXX
+  SG_ MN_MuxSig0_4 m0  : 35|1@1+ (1.0,0.0) [0.0|1] ""  Vector__XXX
+  SG_ MN_MuxSig0_5 m0  : 36|28@1+ (0.000001,0) [0.000000|180.000000] ""  Vector__XXX
+)";
 
 } // namespace test_data
+
+// This is windows newline
+#include "dbc_parser_data_win.hpp"
+

--- a/tests/dbc_parser_data_win.hpp
+++ b/tests/dbc_parser_data_win.hpp
@@ -1,0 +1,12 @@
+#include <cstring>
+
+// Keeping this header in a separate file for the windows newline not to
+// be altered accidentially by the IDE/text editor when saving changes on linux.
+// vi/nano is save, QT Creator will implicitly 'correct' the newline without notice
+
+namespace test_data {
+
+// This is windows newline
+const std::string bo_with_window_endline = R"(BO_ 666 GTW_stupidSt: 3 NEO SG_ GTW_epasTuneRequest : 5|3@1+ (1,0) [8|-1] "" NEO)";
+
+} // namespace test_data

--- a/tests/dbcparser_tests.cpp
+++ b/tests/dbcparser_tests.cpp
@@ -183,13 +183,8 @@ BU_ :
   GTW
 
 )";
-    std::vector<std::string> values{
-        test_data::bo1,
-        test_data::bo2,
-        test_data::bo_with_window_endline,
-        test_data::bo_signed_sigs,
-        test_data::bo_muxed_signals
-    };
+    std::vector<std::string> values{ test_data::bo1, test_data::bo2, test_data::bo_with_window_endline,
+        test_data::bo_signed_sigs, test_data::bo_muxed_signals };
     for (const auto& value : values) {
         dbc += value;
         dbc += "\n";
@@ -257,35 +252,42 @@ BU_ :
 
     // testing for muxed (extended can) signals
 
-    CANmessage muxmsg{ 2589283496, "MN_MuxMsg_01", 8, "MYNODE"};
+    CANmessage muxmsg{ 2589283496, "MN_MuxMsg_01", 8, "MYNODE" };
     EXPECT_EQ(db->messages.find(muxmsg)->first.muxed, true);
 
     // Mux master signal
-    expSig = CANsignal{ "MN_MUX", 0, 2, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 3.0, "", { "Vector__XXX" }, CANsignal::MuxMaster};
+    expSig = CANsignal{ "MN_MUX", 0, 2, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 3.0, "", { "Vector__XXX" },
+        CANsignal::MuxMaster };
     EXPECT_EQ(db->messages.at(muxmsg).at(0), expSig);
 
     // Singular non-muxed signal
-    expSig = CANsignal{ "MN_NonMuxed", 2, 1, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 1.0, "", { "Vector__XXX" }};
+    expSig = CANsignal{ "MN_NonMuxed", 2, 1, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 1.0, "",
+        { "Vector__XXX" } };
     EXPECT_EQ(db->messages.at(muxmsg).at(1), expSig);
 
     // First muxed signal slot 0.1
-    expSig = CANsignal{ "MN_MuxSig0_1", 3, 4, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 15.0, "", { "Vector__XXX" }, 0};
+    expSig = CANsignal{ "MN_MuxSig0_1", 3, 4, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 15.0, "",
+        { "Vector__XXX" }, 0 };
     EXPECT_EQ(db->messages.at(muxmsg).at(2), expSig);
 
     // First muxed signal slot 1.1
-    expSig = CANsignal{ "MN_MuxSig1_1", 4, 12, CANsignal::Intel, CANsignal::Unsigned, 0.1, 0, 0.0, 409.5, "", { "Vector__XXX" }, 1};
+    expSig = CANsignal{ "MN_MuxSig1_1", 4, 12, CANsignal::Intel, CANsignal::Unsigned, 0.1, 0, 0.0, 409.5, "",
+        { "Vector__XXX" }, 1 };
     EXPECT_EQ(db->messages.at(muxmsg).at(3), expSig);
 
     // First muxed signal slot 0.2
-    expSig = CANsignal{ "MN_MuxSig0_2", 7, 1, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 1.0, "", { "Vector__XXX" },  0};
+    expSig = CANsignal{ "MN_MuxSig0_2", 7, 1, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 1.0, "",
+        { "Vector__XXX" }, 0 };
     EXPECT_EQ(db->messages.at(muxmsg).at(4), expSig);
 
     // First muxed signal slot 0.3
-    expSig = CANsignal{ "MN_MuxSig0_3", 8, 27, CANsignal::Intel, CANsignal::Unsigned, 0.000001, 0, 0.0, 90.000000, "", { "Vector__XXX" }, 0};
+    expSig = CANsignal{ "MN_MuxSig0_3", 8, 27, CANsignal::Intel, CANsignal::Unsigned, 0.000001, 0, 0.0, 90.000000, "",
+        { "Vector__XXX" }, 0 };
     EXPECT_EQ(db->messages.at(muxmsg).at(5), expSig);
 
     // First muxed signal slot 1.2
-    expSig = CANsignal{ "MN_MuxSig1_2", 16, 14, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 16383, "", { "Vector__XXX" }, 1};
+    expSig = CANsignal{ "MN_MuxSig1_2", 16, 14, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 16383, "",
+        { "Vector__XXX" }, 1 };
     EXPECT_EQ(db->messages.at(muxmsg).at(6), expSig);
 }
 

--- a/tests/dbcparser_tests.cpp
+++ b/tests/dbcparser_tests.cpp
@@ -183,8 +183,13 @@ BU_ :
   GTW
 
 )";
-    std::vector<std::string> values{ test_data::bo1, test_data::bo2, test_data::bo_with_window_endline,
-        test_data::bo_signed_sigs };
+    std::vector<std::string> values{
+        test_data::bo1,
+        test_data::bo2,
+        test_data::bo_with_window_endline,
+        test_data::bo_signed_sigs,
+        test_data::bo_muxed_signals
+    };
     for (const auto& value : values) {
         dbc += value;
         dbc += "\n";
@@ -249,6 +254,39 @@ BU_ :
 
     expSig = CANsignal{ "FKD_GyroHead", 0, 12, CANsignal::Intel, CANsignal::Unsigned, 0.1, 0, 0, 409.5, "", { "NEO" } };
     EXPECT_EQ(db->messages.at(gyro).at(2), expSig);
+
+    // testing for muxed (extended can) signals
+
+    CANmessage muxmsg{ 2589283496, "MN_MuxMsg_01", 8, "MYNODE"};
+    EXPECT_EQ(db->messages.find(muxmsg)->first.muxed, true);
+
+    // Mux master signal
+    expSig = CANsignal{ "MN_MUX", 0, 2, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 3.0, "", { "Vector__XXX" }, CANsignal::MuxMaster};
+    EXPECT_EQ(db->messages.at(muxmsg).at(0), expSig);
+
+    // Singular non-muxed signal
+    expSig = CANsignal{ "MN_NonMuxed", 2, 1, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 1.0, "", { "Vector__XXX" }};
+    EXPECT_EQ(db->messages.at(muxmsg).at(1), expSig);
+
+    // First muxed signal slot 0.1
+    expSig = CANsignal{ "MN_MuxSig0_1", 3, 4, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 15.0, "", { "Vector__XXX" }, 0};
+    EXPECT_EQ(db->messages.at(muxmsg).at(2), expSig);
+
+    // First muxed signal slot 1.1
+    expSig = CANsignal{ "MN_MuxSig1_1", 4, 12, CANsignal::Intel, CANsignal::Unsigned, 0.1, 0, 0.0, 409.5, "", { "Vector__XXX" }, 1};
+    EXPECT_EQ(db->messages.at(muxmsg).at(3), expSig);
+
+    // First muxed signal slot 0.2
+    expSig = CANsignal{ "MN_MuxSig0_2", 7, 1, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 1.0, "", { "Vector__XXX" },  0};
+    EXPECT_EQ(db->messages.at(muxmsg).at(4), expSig);
+
+    // First muxed signal slot 0.3
+    expSig = CANsignal{ "MN_MuxSig0_3", 8, 27, CANsignal::Intel, CANsignal::Unsigned, 0.000001, 0, 0.0, 90.000000, "", { "Vector__XXX" }, 0};
+    EXPECT_EQ(db->messages.at(muxmsg).at(5), expSig);
+
+    // First muxed signal slot 1.2
+    expSig = CANsignal{ "MN_MuxSig1_2", 16, 14, CANsignal::Intel, CANsignal::Unsigned, 1.0, 0, 0.0, 16383, "", { "Vector__XXX" }, 1};
+    EXPECT_EQ(db->messages.at(muxmsg).at(6), expSig);
 }
 
 TEST_P(ValuesTest, vals)


### PR DESCRIPTION
Muxed messages were not tested and did not seem to work (with production grade, vector compatible OEM dbc).
Reworking the mechanism, adding functional test with anonymized, muxed OEM message.

Side note:
* Adding some headers to CMakeLists.txt for them to show up in the file tree of my IDE (QT Creator). Purely cosmetic but helpful
* Moving the windows newline function test data to a separate file as whenever this is extended and saved, there is a risk of the newline being converted to unix line endings implicitly - depending on the IDE.


Signed-off-by: jenszo <6693266+jenszo@users.noreply.github.com>